### PR TITLE
gaurd against global redefinition of setTimeout

### DIFF
--- a/toobusy.js
+++ b/toobusy.js
@@ -1,4 +1,5 @@
 var setInterval = require("timers").setInterval;
+var clearInterval = require("timers").clearInterval;
 
 var STANDARD_HIGHWATER = 70;
 var STANDARD_INTERVAL = 500;


### PR DESCRIPTION
I ran into a production issue where timers were being redefined for test purposes. The timer redefinition did not emulate node timers, and so `unref` was therefore undefined. While I admit that redefining globals is a bad idea and shouldn't have been done in the first place, in general I think it's good practice to depend on the timers module.  Not only does this guard against the global redefinition but it also allows easier inspection, i.e. we can see which timers are being used upfront.
