### PR TITLE
Update dampening formula and make smoothing factor tunable

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -151,3 +151,12 @@ describe('smoothingFactor', function() {
   });
 });
 
+describe('started', function() {
+  it('should return false after shutdown', function(done) {
+    toobusy.shutdown();
+    (toobusy.started()).should.equal(false);
+    done();
+  });
+});
+
+

--- a/toobusy.js
+++ b/toobusy.js
@@ -88,6 +88,25 @@ toobusy.maxLag = function(newLag){
 };
 
 /**
+ * Set or get the smoothing factor. Default is 0.3333....
+ *
+ * The smoothing factor per the standard exponential smoothing formula "αtn + (1-α)tn-1"
+ * See: https://en.wikipedia.org/wiki/Exponential_smoothing
+ *
+ * @param  {Number} [newFactor] New smoothing factor.
+ * @return {Number}             New or existing smoothing factor.
+ */
+toobusy.smoothingFactor = function(newFactor){
+  if(!newFactor) return smoothingFactor;
+
+  if (typeof newFactor !== "number") throw new Error("NewFactor must be a number.");
+  if(newFactor <= 0 || newFactor > 1) throw new Error("Smoothing factor should be in range ]0,1].");
+
+  smoothingFactor = newFactor;
+  return smoothingFactor;
+};
+
+/**
  * Shuts down toobusy.
  *
  * Not necessary to call this manually, only do this if you know what you're doing. `unref()` is called

--- a/toobusy.js
+++ b/toobusy.js
@@ -9,7 +9,8 @@ var STANDARD_INTERVAL = 500;
 // A dampening factor.  When determining average calls per second or
 // current lag, we weigh the current value against the previous value 2:1
 // to smooth spikes.
-var AVG_DECAY_FACTOR = 3;
+// See https://en.wikipedia.org/wiki/Exponential_smoothing
+var SMOOTHING_FACTOR = 1/3;
 
 //
 // Vars
@@ -18,6 +19,7 @@ var AVG_DECAY_FACTOR = 3;
 var lastTime = Date.now();
 var highWater = STANDARD_HIGHWATER;
 var interval = STANDARD_INTERVAL;
+var smoothingFactor = SMOOTHING_FACTOR;
 var currentLag = 0;
 var checkInterval;
 
@@ -108,8 +110,8 @@ function start() {
     var now = Date.now();
     var lag = now - lastTime;
     lag = Math.max(0, lag - interval);
-    // Dampen lag. See AVG_DECAY_FACTOR initialization at the top of this file.
-    currentLag = (lag + (currentLag * (AVG_DECAY_FACTOR - 1))) / AVG_DECAY_FACTOR;
+    // Dampen lag. See SMOOTHING_FACTOR initialization at the top of this file.
+    currentLag = smoothingFactor * lag + (1 - smoothingFactor) * currentLag;
     lastTime = now;
   }, interval);
 

--- a/toobusy.js
+++ b/toobusy.js
@@ -114,7 +114,7 @@ toobusy.smoothingFactor = function(newFactor){
  */
 toobusy.shutdown = function(){
   currentLag = 0;
-  clearInterval(checkInterval);
+  checkInterval = clearInterval(checkInterval);
 };
 
 toobusy.started = function() {


### PR DESCRIPTION
The dampening was done with an exponential smoothing formula, but it was somewhat "hidden" by supplying a decay factor denominator, instead of the more understood "smoothing factor", which is a number between 0 and 1. See documentation here: https://en.wikipedia.org/wiki/Exponential_smoothing

I modified the code to use the more conventional exponential smoothing formula. Do note that there is no functional change, the 2 formulas are equivalent.

The motivation was to expose a getter/setter for the smoothing factor. I have found that the previous ```AVG_DECAY_FACTOR``` value of 3 (equivalent to a smoothing factor of 0.33333...) wasn't smoothing enough for some apps. This PR therefore also adds a new ```smoothingFactor()``` method, which makes the smoothing factor a tunable (while retaining the old value of 0.33333... as default for backward compatibility).

Because the method is new, and the smoothing factor was previously hardcoded and not exposed, and the formula is equivalent, the PR is backward compatible.

I tried to follow the code style. Feedback welcome. 

PS: I also added a unrelated change to clear ```checkInterval``` on shutdown, otherwise calls to ```toobusy.started()``` were returning ```true``` even after ```toobusy.shutdown()``` had been called (see last commit)