### PR TITLE
Added easing event and fixed currentLag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The default of 70 should get you started.
 As of `0.5.0`, `toobusy-js` exposes an `onLag` method. Pass it a callback to be notified when
 a slow event loop tick has been detected.
 
+An `onEasing` method is also exposed, allowing one to be notified when the server lag appears to be easing. Additionally, one can set the consecutive number of lag spikes required to trigger a lag event using the `consecutiveLags(number)` method.
+
 ## references
 
 > There is nothing new under the sun. (Ecclesiastes 1:9)


### PR DESCRIPTION
Added an easing event (was running tests and was useful to have), and a new configuration method, consecutiveLags(int), which allows one to configure the number of lag spikes required before the onLag() function is triggered.
Additionally, a change to line #186 was made, as the currentLag was being set to NaN as a result of currentlag being set to a number multiplied by 0 (initial currentLag) in previous iterations. Calculations can now occur properly.